### PR TITLE
fix: 修复意外丢失流式chunk

### DIFF
--- a/openai_compatible_server.py
+++ b/openai_compatible_server.py
@@ -231,7 +231,7 @@ def stream_and_update_state(task_id: str, request_base: dict, user_or_tool_messa
             try:
                 # findall直接返回捕获组的内容
                 text = json.loads(f'"{match_group}"')
-                if text and not text.startswith("**"):
+                if text and (len(text.strip()) > 2 or not text.startswith("**")):
                     full_ai_response_text += text
                     yield format_openai_chunk(text, model, request_id)
             except json.JSONDecodeError:
@@ -270,7 +270,7 @@ def generate_non_streaming_response(task_id: str, request_base: dict, user_or_to
             try:
                 # findall直接返回捕获组的内容
                 text = json.loads(f'"{match_group}"')
-                if text and not text.startswith("**"):
+                if text and (len(text.strip()) > 2 or not text.startswith("**")):
                     full_ai_response_text += text
             except json.JSONDecodeError:
                 continue


### PR DESCRIPTION
# 流式输出Chunk丢失问题修复报告

## 问题描述
在某次流式输出中，以下数据块被服务器接收但未传输给API客户端：
```
,[[[[[[null,"**\n    *   一个与内容无关，仅由树的拓扑结构决定的、从 `0` 到 `"]],"model"]]],null,[6676,1642,10240,null,[[1,6676]],null,null,null,null,1922]]
```

## 根因分析

### 原始假设（错误）
最初以为是正则表达式无法匹配深层嵌套结构，但测试证明正则表达式工作正常。

### 真正原因
问题出现在 `openai_compatible_server.py` 第234行的过滤逻辑：
```python
if text and not text.startswith("**"):
```

丢失的文本内容为：
```
**
    *   一个与内容无关，仅由树的拓扑结构决定的、从 `0` 到 `
```

因为以 `**` 开头，被错误过滤掉了。

## 修复方案

### 实施的方案（智能过滤）
将过滤逻辑从：
```python
if text and not text.startswith("**"):
```

修改为：
```python
if text and (len(text.strip()) > 2 or not text.startswith("**")):
```

### 修复逻辑说明
- **保留有效内容**：长度超过2个字符的以 `**` 开头的内容会被保留
- **过滤无意义内容**：仍然过滤纯 `**` 符号和类似的短内容
- **向后兼容**：不影响现有的正常文本处理

## 修复效果验证

### 测试结果
- ✅ 丢失的chunk现在会正确输出
- ✅ 保持对无意义 `**` 符号的过滤
- ✅ 正常文本处理不受影响

### 边界情况测试
| 内容 | 长度 | 结果 | 说明 |
|------|------|------|------|
| `**` | 2 | 🚫 过滤 | 纯符号，正确过滤 |
| `***` | 3 | ✅ 输出 | 可能是列表项 |
| `** ` | 2 | 🚫 过滤 | 实际长度=2 |
| `**a` | 3 | ✅ 输出 | 有效内容 |